### PR TITLE
Implement first iteration of visual control point fence

### DIFF
--- a/battleground_construct/src/config/playground.rs
+++ b/battleground_construct/src/config/playground.rs
@@ -157,4 +157,44 @@ pub fn populate_dev_world(construct: &mut crate::Construct) {
             },
         ),
     );
+
+    // Spawn two teams.
+    let team_red_entity = world.add_entity();
+    let red_team_id = components::id_generator::generate_id(world);
+    let red_team = components::team::Team::new(red_team_id, &"red", Color::RED);
+    let red_team_id = red_team.id();
+    world.add_component(team_red_entity, red_team);
+    let team_blue_id = components::id_generator::generate_id(world);
+    let team_blue_entity = world.add_entity();
+    let blue_team = components::team::Team::new(team_blue_id, &"blue", Color::BLUE);
+    let team_blue_id = blue_team.id();
+    world.add_component(team_blue_entity, blue_team);
+
+    // Spawn a capturable flag.
+    let mut flag_config = crate::units::capturable_flag::CapturableFlagConfig {
+        x: -3.0,
+        y: 5.0,
+        yaw: 0.0,
+        radius: 3.0,
+        capture_speed: 1.0,
+        initial_owner: Some(red_team_id),
+        ..Default::default()
+    };
+    crate::units::capturable_flag::spawn_capturable_flag(world, flag_config);
+    flag_config.initial_owner = Some(team_blue_id);
+    flag_config.x += -7.0;
+    crate::units::capturable_flag::spawn_capturable_flag(world, flag_config);
+
+    spawn_tank(
+        world,
+        TankSpawnConfig {
+            x: -5.0,
+            y: 2.0,
+            yaw: 0.0,
+            // controller: Box::new(control::tank_swivel_shoot::TankSwivelShoot {}),
+            controller: Box::new(unit_control_builtin::idle::Idle{}),
+            ..Default::default()
+        },
+    );
+
 }

--- a/battleground_construct/src/config/playground.rs
+++ b/battleground_construct/src/config/playground.rs
@@ -188,11 +188,18 @@ pub fn populate_dev_world(construct: &mut crate::Construct) {
     spawn_tank(
         world,
         TankSpawnConfig {
-            x: -5.0,
-            y: 2.0,
+            x: -6.5,
+            y: 5.0,
             yaw: 0.0,
             // controller: Box::new(control::tank_swivel_shoot::TankSwivelShoot {}),
-            controller: Box::new(unit_control_builtin::idle::Idle{}),
+            // controller: Box::new(unit_control_builtin::idle::Idle{}),
+            controller: Box::new(
+                unit_control_builtin::diff_drive_forwards_backwards::DiffDriveForwardsBackwardsControl {
+                    velocities: (0.75, 1.0),
+                    last_flip: -1.5,
+                    duration: 3.0,
+                },
+            ),
             ..Default::default()
         },
     );

--- a/battleground_construct/src/display/display_control_point.rs
+++ b/battleground_construct/src/display/display_control_point.rs
@@ -25,15 +25,7 @@ impl DisplayControlPoint {
         }
     }
     pub fn set_color(&mut self, color: Color) {
-        // self.color = color;
-        // self.color.a = 128;
-        // self.color.r = ((color.r as u32 + 128) / 2) as u8;
-        // self.color.g = ((color.g as u32 + 128) / 2) as u8;
-        // self.color.b = ((color.b as u32 + 128) / 2) as u8;
-        // self.color.a = ((color.a as u32 + 128) / 2) as u8;
-        self.color.r = color.r as u8;
-        self.color.g = color.g as u8;
-        self.color.b = color.b as u8;
+        self.color = color;
     }
 
     pub fn set_radius(&mut self, radius: f32) {
@@ -53,7 +45,7 @@ impl Drawable for DisplayControlPoint {
             transform: Mat4::from_angle_y(cgmath::Deg(-90.0)),
             primitive: Primitive::Cylinder(Cylinder {
                 radius: self.radius,
-                height: 0.5,
+                height: 2.0,
             }),
             material,
         }]

--- a/battleground_construct/src/display/display_control_point.rs
+++ b/battleground_construct/src/display/display_control_point.rs
@@ -27,10 +27,13 @@ impl DisplayControlPoint {
     pub fn set_color(&mut self, color: Color) {
         // self.color = color;
         // self.color.a = 128;
-        self.color.r = ((color.r as u32 + 128) / 2) as u8;
-        self.color.g = ((color.g as u32 + 128) / 2) as u8;
-        self.color.b = ((color.b as u32 + 128) / 2) as u8;
+        // self.color.r = ((color.r as u32 + 128) / 2) as u8;
+        // self.color.g = ((color.g as u32 + 128) / 2) as u8;
+        // self.color.b = ((color.b as u32 + 128) / 2) as u8;
         // self.color.a = ((color.a as u32 + 128) / 2) as u8;
+        self.color.r = color.r as u8;
+        self.color.g = color.g as u8;
+        self.color.b = color.b as u8;
     }
 
     pub fn set_radius(&mut self, radius: f32) {
@@ -41,16 +44,16 @@ impl Component for DisplayControlPoint {}
 
 impl Drawable for DisplayControlPoint {
     fn drawables(&self) -> Vec<Element> {
-        let material = Material::FlatMaterial(FlatMaterial {
+        let material = Material::FenceMaterial(FenceMaterial {
             color: self.color,
-            is_transparent: false,
             ..Default::default()
         });
+
         vec![Element {
-            transform: Mat4::from_translation(Vec3::new(0.0, 0.0, 0.001)),
-            primitive: Primitive::Circle(Circle {
+            transform: Mat4::from_angle_y(cgmath::Deg(-90.0)),
+            primitive: Primitive::Cylinder(Cylinder {
                 radius: self.radius,
-                subdivisions: 30,
+                height: 0.5,
             }),
             material,
         }]

--- a/battleground_construct/src/display/primitives.rs
+++ b/battleground_construct/src/display/primitives.rs
@@ -44,7 +44,6 @@ impl Eq for Line {}
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Circle {
     pub radius: f32,
-    pub subdivisions: u32,
 }
 impl Eq for Circle {}
 

--- a/battleground_construct/src/display/primitives.rs
+++ b/battleground_construct/src/display/primitives.rs
@@ -41,9 +41,17 @@ pub struct Line {
 }
 impl Eq for Line {}
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Circle {
+    pub radius: f32,
+    pub subdivisions: u32,
+}
+impl Eq for Circle {}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Primitive {
     Cuboid(Cuboid),
+    Circle(Circle),
     Sphere(Sphere),
     Cylinder(Cylinder),
     Line(Line),

--- a/battleground_construct/src/display/primitives.rs
+++ b/battleground_construct/src/display/primitives.rs
@@ -153,9 +153,22 @@ impl From<Color> for Material {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct FenceMaterial {
+    pub color: Color,
+}
+
+impl Default for FenceMaterial {
+    fn default() -> Self {
+        FenceMaterial {
+            color: Color::MAGENTA,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Material {
     FlatMaterial(FlatMaterial),
-    TeamMaterial,
+    FenceMaterial(FenceMaterial),
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/battleground_construct/src/display/primitives.rs
+++ b/battleground_construct/src/display/primitives.rs
@@ -41,17 +41,9 @@ pub struct Line {
 }
 impl Eq for Line {}
 
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Circle {
-    pub radius: f32,
-    pub subdivisions: u32,
-}
-impl Eq for Circle {}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Primitive {
     Cuboid(Cuboid),
-    Circle(Circle),
     Sphere(Sphere),
     Cylinder(Cylinder),
     Line(Line),

--- a/battleground_construct/src/units/capturable_flag.rs
+++ b/battleground_construct/src/units/capturable_flag.rs
@@ -3,6 +3,7 @@ use crate::display;
 use components::pose::Pose;
 use engine::prelude::*;
 
+#[derive(Copy, Clone, Debug)]
 pub struct CapturableFlagConfig {
     pub x: f32,
     pub y: f32,

--- a/battleground_viewer/src/construct_render/construct_render.rs
+++ b/battleground_viewer/src/construct_render/construct_render.rs
@@ -60,7 +60,6 @@ impl DrawableKey for battleground_construct::display::primitives::Primitive {
             Primitive::Circle(circle) => {
                 5usize.hash(state);
                 circle.radius.to_bits().hash(state);
-                circle.subdivisions.hash(state);
             }
         }
         // val
@@ -830,7 +829,7 @@ impl ConstructRender {
                 m
             }
             display::primitives::Primitive::Cylinder(cylinder) => {
-                let mut m = CpuMesh::cylinder(32);
+                let mut m = CpuMesh::cylinder(128);
                 m.transform(&Mat4::from_nonuniform_scale(
                     cylinder.height,
                     cylinder.radius,
@@ -840,7 +839,7 @@ impl ConstructRender {
                 m
             }
             display::primitives::Primitive::Cone(cone) => {
-                let mut m = CpuMesh::cone(32);
+                let mut m = CpuMesh::cone(128);
                 m.transform(&Mat4::from_nonuniform_scale(
                     cone.height,
                     cone.radius,
@@ -851,7 +850,7 @@ impl ConstructRender {
             }
             display::primitives::Primitive::Line(_line) => CpuMesh::cylinder(4),
             display::primitives::Primitive::Circle(circle) => {
-                let mut m = CpuMesh::circle(circle.subdivisions);
+                let mut m = CpuMesh::circle(128);
                 m.transform(&Mat4::from_scale(circle.radius)).unwrap();
                 m
             }

--- a/battleground_viewer/src/construct_render/construct_render.rs
+++ b/battleground_viewer/src/construct_render/construct_render.rs
@@ -825,12 +825,12 @@ impl ConstructRender {
                 m
             }
             display::primitives::Primitive::Sphere(sphere) => {
-                let mut m = CpuMesh::sphere(16);
+                let mut m = CpuMesh::sphere(32);
                 m.transform(&Mat4::from_scale(sphere.radius)).unwrap();
                 m
             }
             display::primitives::Primitive::Cylinder(cylinder) => {
-                let mut m = CpuMesh::cylinder(16);
+                let mut m = CpuMesh::cylinder(32);
                 m.transform(&Mat4::from_nonuniform_scale(
                     cylinder.height,
                     cylinder.radius,
@@ -840,7 +840,7 @@ impl ConstructRender {
                 m
             }
             display::primitives::Primitive::Cone(cone) => {
-                let mut m = CpuMesh::cone(16);
+                let mut m = CpuMesh::cone(32);
                 m.transform(&Mat4::from_nonuniform_scale(
                     cone.height,
                     cone.radius,

--- a/battleground_viewer/src/construct_render/construct_render.rs
+++ b/battleground_viewer/src/construct_render/construct_render.rs
@@ -57,11 +57,6 @@ impl DrawableKey for battleground_construct::display::primitives::Primitive {
                 cone.radius.to_bits().hash(state);
                 cone.height.to_bits().hash(state);
             }
-            Primitive::Circle(circle) => {
-                5usize.hash(state);
-                circle.radius.to_bits().hash(state);
-                circle.subdivisions.hash(state);
-            }
         }
         // val
         hasher.finish()
@@ -758,12 +753,7 @@ impl ConstructRender {
                 .unwrap();
                 m
             }
-            display::primitives::Primitive::Line(_line) => CpuMesh::cylinder(4),
-            display::primitives::Primitive::Circle(circle) => {
-                let mut m = CpuMesh::circle(circle.subdivisions);
-                m.transform(&Mat4::from_scale(circle.radius)).unwrap();
-                m
-            }
+            display::primitives::Primitive::Line(_line) => CpuMesh::cylinder(4)
         }
     }
 }

--- a/battleground_viewer/src/construct_render/construct_render.rs
+++ b/battleground_viewer/src/construct_render/construct_render.rs
@@ -57,6 +57,11 @@ impl DrawableKey for battleground_construct::display::primitives::Primitive {
                 cone.radius.to_bits().hash(state);
                 cone.height.to_bits().hash(state);
             }
+            Primitive::Circle(circle) => {
+                5usize.hash(state);
+                circle.radius.to_bits().hash(state);
+                circle.subdivisions.hash(state);
+            }
         }
         // val
         hasher.finish()
@@ -845,6 +850,11 @@ impl ConstructRender {
                 m
             }
             display::primitives::Primitive::Line(_line) => CpuMesh::cylinder(4),
+            display::primitives::Primitive::Circle(circle) => {
+                let mut m = CpuMesh::circle(circle.subdivisions);
+                m.transform(&Mat4::from_scale(circle.radius)).unwrap();
+                m
+            }
         }
     }
 }

--- a/battleground_viewer/src/construct_render/effects.rs
+++ b/battleground_viewer/src/construct_render/effects.rs
@@ -490,6 +490,7 @@ impl Deconstructor {
                         },
                     )
                 }
+                battleground_construct::display::primitives::Primitive::Circle(_) => todo!(),
             };
 
             for fragment in fragments {

--- a/battleground_viewer/src/construct_render/effects.rs
+++ b/battleground_viewer/src/construct_render/effects.rs
@@ -490,7 +490,6 @@ impl Deconstructor {
                         },
                     )
                 }
-                battleground_construct::display::primitives::Primitive::Circle(_) => todo!(),
             };
 
             for fragment in fragments {

--- a/battleground_viewer/src/fence_material.rs
+++ b/battleground_viewer/src/fence_material.rs
@@ -21,7 +21,7 @@ impl<'a> FenceMaterial<'a> {
                 blend: Blend::TRANSPARENCY,
                 ..Default::default()
             },
-            depth_texture
+            depth_texture,
         }
     }
 }

--- a/battleground_viewer/src/fence_material.rs
+++ b/battleground_viewer/src/fence_material.rs
@@ -1,0 +1,45 @@
+use three_d::*;
+
+#[derive(Clone, Default)]
+pub struct FenceMaterial {
+    pub color: Color,
+    pub render_states: RenderStates,
+}
+
+impl FenceMaterial {
+    pub fn new() -> Self {
+        Self {
+            color: Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
+            render_states: RenderStates {
+                write_mask: WriteMask::COLOR,
+                blend: Blend::TRANSPARENCY,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl Material for FenceMaterial {
+    fn fragment_shader_source(&self, use_vertex_colors: bool, _lights: &[&dyn Light]) -> String {
+        let mut shader = String::new();
+        if use_vertex_colors {
+            shader.push_str("#define USE_VERTEX_COLORS\nin vec4 col;\n");
+        }
+        shader.push_str(include_str!("shaders/fence_material.frag"));
+        shader
+    }
+    fn use_uniforms(&self, program: &Program, _camera: &Camera, _lights: &[&dyn Light]) {
+        program.use_uniform("surfaceColor", self.color);
+    }
+    fn render_states(&self) -> RenderStates {
+        self.render_states
+    }
+    fn material_type(&self) -> MaterialType {
+        MaterialType::Transparent
+    }
+}

--- a/battleground_viewer/src/lib.rs
+++ b/battleground_viewer/src/lib.rs
@@ -276,6 +276,14 @@ impl ConstructViewer {
 
             for e in frame_input.events.iter() {
                 match *e {
+                    three_d::Event::KeyPress {
+                        kind: Key::Space,
+                        handled: false,
+                        ..
+                    } => {
+                        viewer_state.paused = !viewer_state.paused;
+                        self.limiter.set_paused(viewer_state.paused);
+                    }
                     three_d::Event::MousePress {
                         button,
                         position,

--- a/battleground_viewer/src/lib.rs
+++ b/battleground_viewer/src/lib.rs
@@ -375,7 +375,7 @@ impl ConstructViewer {
                 Wrapping::ClampToEdge,
             );
 
-            let depth_material = DepthMaterial {
+            let write_depth_material = ColorMaterial {
                 render_states: RenderStates {
                     write_mask: WriteMask::DEPTH,
                     ..Default::default()
@@ -386,7 +386,7 @@ impl ConstructViewer {
                 .as_depth_target()
                 .clear(ClearState::default())
                 .render_with_material(
-                    &depth_material,
+                    &write_depth_material,
                     &self.camera,
                     &self.construct_render.non_emissive_meshes(),
                     &[],
@@ -411,7 +411,7 @@ impl ConstructViewer {
             .render(&self.camera, &self.construct_render.emissive_objects(), &[]);
 
             // C) Render fence meshes to framebuffer (with bound depth texture)
-            let fence_material = FenceMaterial::new();
+            let fence_material = FenceMaterial::new(&depth_texture);
             screen.render_with_material(
                 &fence_material,
                 &self.camera,

--- a/battleground_viewer/src/shaders/fence_material.frag
+++ b/battleground_viewer/src/shaders/fence_material.frag
@@ -43,8 +43,11 @@ void main()
     float d = distance(fencePosition, backgroundPosition);
 
     // Use distance to blend in fence near things
-    float f = exp(-11.09 * pow(d, 4));
-    outColor.a = f;
+    // float f = exp(-11.09 * pow(d, 4));
+    const float lineWidth = 0.1;
+    float fade = exp(-2.0 * (d + 0.2));
+    float step = floor(-d + lineWidth) + 1.0;
+    outColor.a = max(fade, step);
 
     // Convert color space
     outColor.rgb = srgb_from_rgb(outColor.rgb);

--- a/battleground_viewer/src/shaders/fence_material.frag
+++ b/battleground_viewer/src/shaders/fence_material.frag
@@ -1,0 +1,27 @@
+uniform vec4 surfaceColor;
+
+layout (location = 0) out vec4 outColor;
+
+
+vec3 srgb_from_rgb(vec3 rgb) {
+	vec3 a = vec3(0.055, 0.055, 0.055);
+	vec3 ap1 = vec3(1.0, 1.0, 1.0) + a;
+	vec3 g = vec3(2.4, 2.4, 2.4);
+	vec3 ginv = 1.0 / g;
+	vec3 select = step(vec3(0.0031308, 0.0031308, 0.0031308), rgb);
+	vec3 lo = rgb * 12.92;
+	vec3 hi = ap1 * pow(rgb, ginv) - a;
+	return mix(lo, hi, select);
+}
+
+void main()
+{
+    outColor = surfaceColor;
+
+    #ifdef USE_VERTEX_COLORS
+    outColor *= col;
+    #endif
+
+    outColor.a = 0.5;
+    outColor.rgb = srgb_from_rgb(outColor.rgb);
+}


### PR DESCRIPTION
The current control point gives a good visual indication of the current owner, but can produce z-fighting and completely disappears below the floor from certain angles.

I propose to instead display the extent of the capture area with a fence:
![Battleground Construct](https://user-images.githubusercontent.com/829324/210149726-4a4afc9f-1545-40f0-861d-a9f895b03629.png)
This is a first iteration on the visual of the control point. Some things that still need to be adjusted:
- The current visual is far to bright to be readable --- it draws attention away from the units and towards the control point.
- The control point's area surface is unemphasized, which is clearly not desirable, so some fidgeting should be done to still visually hint at the area.

(Also, the addition of the `fence_meshes` member and the associated function stretches the `ConstructRender` as far as I am willing to stretch it without refactoring.)